### PR TITLE
Add entity_category to binary sensor and switch schemas

### DIFF
--- a/components/ampinvt/binary_sensor.py
+++ b/components/ampinvt/binary_sensor.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-
 from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import AMPINVT_COMPONENT_SCHEMA, CONF_AMPINVT_ID


### PR DESCRIPTION
Add entity_category=ENTITY_CATEGORY_DIAGNOSTIC to all binary sensors (they report hardware state and protection events). Add entity_category=ENTITY_CATEGORY_CONFIG to configuration switches (bluetooth, buzzer, display). Primary functional switches (charging, discharging, balancer) remain uncategorized. This improves the Home Assistant entity list organization.