### PR TITLE
Add missing CODEOWNERS to platform files

### DIFF
--- a/components/ampinvt/binary_sensor.py
+++ b/components/ampinvt/binary_sensor.py
@@ -6,6 +6,7 @@ from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 from . import AMPINVT_COMPONENT_SCHEMA, CONF_AMPINVT_ID
 
 DEPENDENCIES = ["ampinvt"]
+CODEOWNERS = ["@syssi"]
 
 CONF_OPERATING_STATUS = "operating_status"
 CONF_BATTERY_STATUS = "battery_status"

--- a/components/ampinvt/sensor.py
+++ b/components/ampinvt/sensor.py
@@ -20,6 +20,7 @@ from esphome.const import (
 from . import AMPINVT_COMPONENT_SCHEMA, CONF_AMPINVT_ID
 
 DEPENDENCIES = ["ampinvt"]
+CODEOWNERS = ["@syssi"]
 
 CONF_PV_VOLTAGE = "pv_voltage"
 CONF_CHARGE_CURRENT = "charge_current"

--- a/components/ampinvt/text_sensor.py
+++ b/components/ampinvt/text_sensor.py
@@ -5,6 +5,7 @@ import esphome.config_validation as cv
 from . import AMPINVT_COMPONENT_SCHEMA, CONF_AMPINVT_ID
 
 DEPENDENCIES = ["ampinvt"]
+CODEOWNERS = ["@syssi"]
 
 CONF_OPERATION_STATUS = "operation_status"
 


### PR DESCRIPTION
Add `CODEOWNERS = ["@syssi"]` to `sensor.py`, `binary_sensor.py`, and `text_sensor.py` for consistency with other ESPHome components.