### PR TITLE
Implement 0xB2 settings frame decoder

### DIFF
--- a/components/ampinvt/ampinvt.cpp
+++ b/components/ampinvt/ampinvt.cpp
@@ -16,6 +16,12 @@ static const char *const OPERATION_STATUS_CHARGING = "Charging";
 static const char *const OPERATION_STATUS_NOT_CHARGING = "Not Charging";
 static const char *const OPERATION_STATUS_OFFLINE = "Offline";
 
+static constexpr const char *const BATTERY_TYPES[] = {"Lead-acid maintenance free", "Lead-acid Gel",
+                                                       "Lead-acid liquid", "Lithium"};
+static constexpr const char *const LOAD_CONTROL[] = {"Off", "Auto", "Time control", "Light control",
+                                                      "Remote control"};
+static constexpr const char *const BAUD_RATES[] = {"", "1200", "2400", "4800", "9600"};
+
 namespace OperationStatusBits {
 static const uint8_t OPERATING = 0x1;               // 00000001
 static const uint8_t BATTERY = 0x2;                 // 00000010
@@ -54,6 +60,7 @@ void Ampinvt::on_ampinvt_modbus_data(const std::vector<uint8_t> &data) {
   switch (function) {
     case AMPINVT_COMMAND_STATUS:
       this->on_ampinvt_status_data_(data);
+      this->send(AMPINVT_COMMAND_SETTINGS, 0x00, 0x00);
       return;
     case AMPINVT_COMMAND_SETTINGS:
       this->on_ampinvt_settings_data_(data);
@@ -157,7 +164,35 @@ void Ampinvt::on_ampinvt_settings_data_(const std::vector<uint8_t> &data) {
     return;
   }
 
-  ESP_LOGI(TAG, "Settings frame decoder not implemented yet");
+  auto get_16bit = [&](size_t i) -> uint16_t { return (uint16_t(data[i]) << 8) | uint16_t(data[i + 1]); };
+
+  uint8_t battery_type = data[3];
+  uint8_t load_ctrl = data[6];
+  uint8_t baud = data[8];
+
+  ESP_LOGI(TAG, "Settings:");
+  ESP_LOGI(TAG, "  Battery type:        %s (%u)", battery_type < 4 ? BATTERY_TYPES[battery_type] : "Unknown",
+           battery_type);
+  ESP_LOGI(TAG, "  Identification:      %s", data[4] == 0 ? "Auto recognition" : "Manual setting");
+  ESP_LOGI(TAG, "  Number of batteries: %u", data[5]);
+  ESP_LOGI(TAG, "  Load control:        %s (%u)", load_ctrl < 5 ? LOAD_CONTROL[load_ctrl] : "Unknown", load_ctrl);
+  ESP_LOGI(TAG, "  Local address:       %u", data[7]);
+  ESP_LOGI(TAG, "  Baud rate:           %s bps", baud >= 1 && baud <= 4 ? BAUD_RATES[baud] : "Unknown");
+  ESP_LOGI(TAG, "  Rated voltage:       %.2f V", get_16bit(9) * 0.01f);
+  ESP_LOGI(TAG, "  Equal charge V max:  %.2f V", get_16bit(11) * 0.01f);
+  ESP_LOGI(TAG, "  Float charge V max:  %.2f V", get_16bit(13) * 0.01f);
+  ESP_LOGI(TAG, "  Discharge V min:     %.2f V", get_16bit(15) * 0.01f);
+  ESP_LOGI(TAG, "  HW max charge curr:  %.2f A", get_16bit(17) * 0.01f);
+  ESP_LOGI(TAG, "  Max charge curr:     %.2f A", get_16bit(19) * 0.01f);
+  ESP_LOGI(TAG, "  Running charge curr: %.2f A", get_16bit(21) * 0.01f);
+  ESP_LOGI(TAG, "  Model code:          0x%02X", data[23]);
+  ESP_LOGI(TAG, "  Over-discharge rec:  %.2f V", get_16bit(25) * 0.01f);
+  ESP_LOGI(TAG, "  OV protection V:     %.2f V", get_16bit(27) * 0.01f);
+  ESP_LOGI(TAG, "  OV recovery V:       %.2f V", get_16bit(29) * 0.01f);
+  ESP_LOGI(TAG, "  Light ctrl ON  PV:   %u V", get_16bit(31));
+  ESP_LOGI(TAG, "  Light ctrl OFF PV:   %u V", get_16bit(33));
+  ESP_LOGI(TAG, "  Delay turn-on:       %u s", get_16bit(35));
+  ESP_LOGI(TAG, "  Delay turn-off:      %u s", get_16bit(37));
 }
 
 void Ampinvt::on_anenji_status_data_(const std::vector<uint8_t> &data) {

--- a/components/ampinvt/ampinvt.cpp
+++ b/components/ampinvt/ampinvt.cpp
@@ -16,10 +16,9 @@ static const char *const OPERATION_STATUS_CHARGING = "Charging";
 static const char *const OPERATION_STATUS_NOT_CHARGING = "Not Charging";
 static const char *const OPERATION_STATUS_OFFLINE = "Offline";
 
-static constexpr const char *const BATTERY_TYPES[] = {"Lead-acid maintenance free", "Lead-acid Gel",
-                                                       "Lead-acid liquid", "Lithium"};
-static constexpr const char *const LOAD_CONTROL[] = {"Off", "Auto", "Time control", "Light control",
-                                                      "Remote control"};
+static constexpr const char *const BATTERY_TYPES[] = {"Lead-acid maintenance free", "Lead-acid Gel", "Lead-acid liquid",
+                                                      "Lithium"};
+static constexpr const char *const LOAD_CONTROL[] = {"Off", "Auto", "Time control", "Light control", "Remote control"};
 static constexpr const char *const BAUD_RATES[] = {"", "1200", "2400", "4800", "9600"};
 
 namespace OperationStatusBits {


### PR DESCRIPTION
## Summary

- Decodes all relevant fields from the 64-byte `0xB2` settings response and logs them at INFO level
- Re-enables the `0xB2` settings request after each status poll (was commented out)

**Fields decoded:**

| Byte(s) | Field |
|---------|-------|
| 3 | Battery type (Lead-acid MF / Gel / Liquid / Lithium) |
| 4 | Identification method (Auto / Manual) |
| 5 | Number of batteries |
| 6 | Load control method |
| 7 | Local address |
| 8 | Baud rate |
| 9-10 | Rated voltage (0.01 V resolution) |
| 11-12 | Equal charge voltage upper limit (0.01 V resolution) |
| 13-14 | Float charge voltage upper limit (0.01 V resolution) |
| 15-16 | Discharge voltage lower limit (0.01 V resolution) |
| 17-18 | HW max charge current, user-unchangeable (0.01 A resolution) |
| 19-20 | Max charge current limit (0.01 A resolution) |
| 21-22 | Running charging current limit (0.01 A resolution) |
| 23 | Model code |
| 25-26 | Over-discharge recovery voltage (0.01 V resolution) |
| 27-28 | Battery overvoltage protection voltage (0.01 V resolution) |
| 29-30 | Battery overvoltage recovery voltage (0.01 V resolution) |
| 31-32 | Light control turn-on PV voltage (V) |
| 33-34 | Light control turn-off PV voltage (V) |
| 35-36 | Delay turn-on time (s) |
| 37-38 | Delay turn-off time (s) |

## Test plan

- [x] Flash device and confirm settings frame is logged after each status poll
- [x] Verify decoded values match the device's configuration display
