### PR TITLE
Implement 0xA2 settings frame decoder

### DIFF
--- a/components/ampinvt/ampinvt.cpp
+++ b/components/ampinvt/ampinvt.cpp
@@ -66,6 +66,7 @@ void Ampinvt::on_ampinvt_modbus_data(const std::vector<uint8_t> &data) {
       return;
     case ANENJI_COMMAND_STATUS:
       this->on_anenji_status_data_(data);
+      this->send(ANENJI_COMMAND_SETTINGS, 0x00, 0x00);
       return;
     case ANENJI_COMMAND_SETTINGS:
       this->on_anenji_settings_data_(data);
@@ -163,7 +164,9 @@ void Ampinvt::on_ampinvt_settings_data_(const std::vector<uint8_t> &data) {
     return;
   }
 
-  auto get_16bit = [&](size_t i) -> uint16_t { return (uint16_t(data[i]) << 8) | uint16_t(data[i + 1]); };
+  auto ampinvt_get_16bit = [&](size_t i) -> uint16_t {
+    return (uint16_t(data[i + 0]) << 8) | (uint16_t(data[i + 1]) << 0);
+  };
 
   uint8_t battery_type = data[3];
   uint8_t load_ctrl = data[6];
@@ -177,21 +180,21 @@ void Ampinvt::on_ampinvt_settings_data_(const std::vector<uint8_t> &data) {
   ESP_LOGI(TAG, "  Load control:        %s (%u)", load_ctrl < 5 ? LOAD_CONTROL[load_ctrl] : "Unknown", load_ctrl);
   ESP_LOGI(TAG, "  Local address:       %u", data[7]);
   ESP_LOGI(TAG, "  Baud rate:           %s bps", baud >= 1 && baud <= 4 ? BAUD_RATES[baud] : "Unknown");
-  ESP_LOGI(TAG, "  Rated voltage:       %.2f V", get_16bit(9) * 0.01f);
-  ESP_LOGI(TAG, "  Equal charge V max:  %.2f V", get_16bit(11) * 0.01f);
-  ESP_LOGI(TAG, "  Float charge V max:  %.2f V", get_16bit(13) * 0.01f);
-  ESP_LOGI(TAG, "  Discharge V min:     %.2f V", get_16bit(15) * 0.01f);
-  ESP_LOGI(TAG, "  HW max charge curr:  %.2f A", get_16bit(17) * 0.01f);
-  ESP_LOGI(TAG, "  Max charge curr:     %.2f A", get_16bit(19) * 0.01f);
-  ESP_LOGI(TAG, "  Running charge curr: %.2f A", get_16bit(21) * 0.01f);
+  ESP_LOGI(TAG, "  Rated voltage:       %.2f V", ampinvt_get_16bit(9) * 0.01f);
+  ESP_LOGI(TAG, "  Equal charge V max:  %.2f V", ampinvt_get_16bit(11) * 0.01f);
+  ESP_LOGI(TAG, "  Float charge V max:  %.2f V", ampinvt_get_16bit(13) * 0.01f);
+  ESP_LOGI(TAG, "  Discharge V min:     %.2f V", ampinvt_get_16bit(15) * 0.01f);
+  ESP_LOGI(TAG, "  HW max charge curr:  %.2f A", ampinvt_get_16bit(17) * 0.01f);
+  ESP_LOGI(TAG, "  Max charge curr:     %.2f A", ampinvt_get_16bit(19) * 0.01f);
+  ESP_LOGI(TAG, "  Running charge curr: %.2f A", ampinvt_get_16bit(21) * 0.01f);
   ESP_LOGI(TAG, "  Model code:          0x%02X", data[23]);
-  ESP_LOGI(TAG, "  Over-discharge rec:  %.2f V", get_16bit(25) * 0.01f);
-  ESP_LOGI(TAG, "  OV protection V:     %.2f V", get_16bit(27) * 0.01f);
-  ESP_LOGI(TAG, "  OV recovery V:       %.2f V", get_16bit(29) * 0.01f);
-  ESP_LOGI(TAG, "  Light ctrl ON  PV:   %u V", get_16bit(31));
-  ESP_LOGI(TAG, "  Light ctrl OFF PV:   %u V", get_16bit(33));
-  ESP_LOGI(TAG, "  Delay turn-on:       %u s", get_16bit(35));
-  ESP_LOGI(TAG, "  Delay turn-off:      %u s", get_16bit(37));
+  ESP_LOGI(TAG, "  Over-discharge rec:  %.2f V", ampinvt_get_16bit(25) * 0.01f);
+  ESP_LOGI(TAG, "  OV protection V:     %.2f V", ampinvt_get_16bit(27) * 0.01f);
+  ESP_LOGI(TAG, "  OV recovery V:       %.2f V", ampinvt_get_16bit(29) * 0.01f);
+  ESP_LOGI(TAG, "  Light ctrl ON  PV:   %u V", ampinvt_get_16bit(31));
+  ESP_LOGI(TAG, "  Light ctrl OFF PV:   %u V", ampinvt_get_16bit(33));
+  ESP_LOGI(TAG, "  Delay turn-on:       %u s", ampinvt_get_16bit(35));
+  ESP_LOGI(TAG, "  Delay turn-off:      %u s", ampinvt_get_16bit(37));
 }
 
 void Ampinvt::on_anenji_status_data_(const std::vector<uint8_t> &data) {
@@ -261,10 +264,31 @@ void Ampinvt::on_anenji_settings_data_(const std::vector<uint8_t> &data) {
     return (uint16_t(data[i + 0]) << 8) | (uint16_t(data[i + 1]) << 0);
   };
 
-  this->publish_state_(this->nominal_voltage_sensor_, ampinvt_get_16bit(9) * 0.01f);
+  uint8_t battery_type = data[3];
+  uint8_t load_ctrl = data[6];
+  uint8_t baud = data[8];
+
+  ESP_LOGI(TAG, "Settings:");
+  ESP_LOGI(TAG, "  Battery type:        %s (%u)", battery_type < 4 ? BATTERY_TYPES[battery_type] : "Unknown",
+           battery_type);
+  ESP_LOGI(TAG, "  Identification:      %s", data[4] == 0 ? "Auto recognition" : "Manual setting");
+  ESP_LOGI(TAG, "  Number of batteries: %u", data[5]);
+  ESP_LOGI(TAG, "  Load control:        %s (%u)", load_ctrl < 5 ? LOAD_CONTROL[load_ctrl] : "Unknown", load_ctrl);
+  ESP_LOGI(TAG, "  Local address:       %u", data[7]);
+  ESP_LOGI(TAG, "  Baud rate:           %s bps", baud >= 1 && baud <= 4 ? BAUD_RATES[baud] : "Unknown");
+
+  ESP_LOGI(TAG, "  Rated voltage:       %.2f V", ampinvt_get_16bit(9) * 0.01f);
+  this->publish_state_(this->rated_voltage_sensor_, ampinvt_get_16bit(9) * 0.01f);
+
+  ESP_LOGI(TAG, "  Equal charge V max:  %.2f V", ampinvt_get_16bit(11) * 0.01f);
+  ESP_LOGI(TAG, "  Float charge V max:  %.2f V", ampinvt_get_16bit(13) * 0.01f);
+  ESP_LOGI(TAG, "  Discharge V min:     %.2f V", ampinvt_get_16bit(15) * 0.01f);
+  ESP_LOGI(TAG, "  HW max charge curr:  %.2f A", ampinvt_get_16bit(17) * 0.01f);
+
+  ESP_LOGI(TAG, "  Max charge curr:     %.2f A", ampinvt_get_16bit(19) * 0.01f);
   this->publish_state_(this->max_charge_current_limit_sensor_, ampinvt_get_16bit(19) * 0.01f);
-  ESP_LOGI(TAG, "Settings: Nominal: %.2fV  MaxCurrent: %.2fA", ampinvt_get_16bit(9) * 0.01f,
-           ampinvt_get_16bit(19) * 0.01f);
+
+  ESP_LOGI(TAG, "  Running charge curr: %.2f A", ampinvt_get_16bit(21) * 0.01f);
 }
 
 void Ampinvt::publish_device_unavailable_() {
@@ -279,7 +303,7 @@ void Ampinvt::publish_device_unavailable_() {
   this->publish_state_(this->battery_temperature_sensor_, NAN);
   this->publish_state_(this->today_yield_sensor_, NAN);
   this->publish_state_(this->generation_total_sensor_, NAN);
-  this->publish_state_(this->nominal_voltage_sensor_, NAN);
+  this->publish_state_(this->rated_voltage_sensor_, NAN);
   this->publish_state_(this->max_charge_current_limit_sensor_, NAN);
 }
 
@@ -368,7 +392,7 @@ void Ampinvt::dump_config() {
   LOG_SENSOR("", "Battery Temperature", this->battery_temperature_sensor_);
   LOG_SENSOR("", "Today Yield", this->today_yield_sensor_);
   LOG_SENSOR("", "Generation Total", this->generation_total_sensor_);
-  LOG_SENSOR("", "Nominal Voltage", this->nominal_voltage_sensor_);
+  LOG_SENSOR("", "Rated Voltage", this->rated_voltage_sensor_);
   LOG_SENSOR("", "Max Charge Current Limit", this->max_charge_current_limit_sensor_);
 
   LOG_TEXT_SENSOR("", "Operation Status", this->operation_status_text_sensor_);

--- a/components/ampinvt/ampinvt.h
+++ b/components/ampinvt/ampinvt.h
@@ -109,9 +109,7 @@ class Ampinvt : public PollingComponent, public ampinvt_modbus::AmpinvtModbusDev
   void set_generation_total_sensor(sensor::Sensor *generation_total_sensor) {
     generation_total_sensor_ = generation_total_sensor;
   }
-  void set_nominal_voltage_sensor(sensor::Sensor *nominal_voltage_sensor) {
-    nominal_voltage_sensor_ = nominal_voltage_sensor;
-  }
+  void set_rated_voltage_sensor(sensor::Sensor *rated_voltage_sensor) { rated_voltage_sensor_ = rated_voltage_sensor; }
   void set_max_charge_current_limit_sensor(sensor::Sensor *max_charge_current_limit_sensor) {
     max_charge_current_limit_sensor_ = max_charge_current_limit_sensor;
   }
@@ -159,7 +157,7 @@ class Ampinvt : public PollingComponent, public ampinvt_modbus::AmpinvtModbusDev
   sensor::Sensor *battery_temperature_sensor_{nullptr};
   sensor::Sensor *today_yield_sensor_{nullptr};
   sensor::Sensor *generation_total_sensor_{nullptr};
-  sensor::Sensor *nominal_voltage_sensor_{nullptr};
+  sensor::Sensor *rated_voltage_sensor_{nullptr};
   sensor::Sensor *max_charge_current_limit_sensor_{nullptr};
 
   Protocol protocol_{Protocol::AMPINVT};

--- a/components/ampinvt/sensor.py
+++ b/components/ampinvt/sensor.py
@@ -27,7 +27,7 @@ CONF_MPPT_TEMPERATURE = "mppt_temperature"
 CONF_BATTERY_TEMPERATURE = "battery_temperature"
 CONF_TODAY_YIELD = "today_yield"
 CONF_GENERATION_TOTAL = "generation_total"
-CONF_NOMINAL_VOLTAGE = "nominal_voltage"
+CONF_RATED_VOLTAGE = "rated_voltage"
 CONF_MAX_CHARGE_CURRENT_LIMIT = "max_charge_current_limit"
 
 # key: sensor_schema kwargs
@@ -74,7 +74,7 @@ SENSOR_DEFS = {
         "device_class": DEVICE_CLASS_ENERGY,
         "state_class": STATE_CLASS_TOTAL_INCREASING,
     },
-    CONF_NOMINAL_VOLTAGE: {
+    CONF_RATED_VOLTAGE: {
         "unit_of_measurement": UNIT_VOLT,
         "accuracy_decimals": 2,
         "device_class": DEVICE_CLASS_VOLTAGE,

--- a/esp32-anenji-example-faker.yaml
+++ b/esp32-anenji-example-faker.yaml
@@ -3,7 +3,7 @@
 # Replay real frames captured from issue #5 (github.com/syssi/esphome-ampinvt/issues/5)
 # 0xA3 frames: real data from Marcepanfazik's working ANJ-48V-100A at 23.5V PV / 12.59V battery
 # 0xA2 frame: synthetic (no captured raw bytes available), values match issue log output:
-#   Nominal Voltage: 48.00V, Max Charge Current Limit: 100.00A, Float Voltage: 54.40V
+#   Rated Voltage: 48.00V, Max Charge Current Limit: 100.00A, Float Voltage: 54.40V
 interval:
   - interval: 9s
     then:
@@ -25,7 +25,7 @@ interval:
 
       - delay: 3s
 
-      # 0xA2 settings frame: Nominal=48.00V  Float=54.40V  MaxCurrent=100.00A
+      # 0xA2 settings frame: Rated=48.00V  Float=54.40V  MaxCurrent=100.00A
       - lambda: |-
           id(ampinvt0).on_ampinvt_modbus_data({
             0x01, 0xA2, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0xC0,

--- a/esp32-anenji-example.yaml
+++ b/esp32-anenji-example.yaml
@@ -108,8 +108,8 @@ sensor:
       name: "MPPT Temperature"
     battery_temperature:
       name: "Battery Temperature"
-    nominal_voltage:
-      name: "Nominal Voltage"
+    rated_voltage:
+      name: "Rated Voltage"
     max_charge_current_limit:
       name: "Max Charge Current Limit"
 

--- a/esp8266-anenji-example-faker.yaml
+++ b/esp8266-anenji-example-faker.yaml
@@ -3,7 +3,7 @@
 # Replay real frames captured from issue #5 (github.com/syssi/esphome-ampinvt/issues/5)
 # 0xA3 frames: real data from Marcepanfazik's working ANJ-48V-100A at 23.5V PV / 12.59V battery
 # 0xA2 frame: synthetic (no captured raw bytes available), values match issue log output:
-#   Nominal Voltage: 48.00V, Max Charge Current Limit: 100.00A, Float Voltage: 54.40V
+#   Rated Voltage: 48.00V, Max Charge Current Limit: 100.00A, Float Voltage: 54.40V
 interval:
   - interval: 9s
     then:
@@ -25,7 +25,7 @@ interval:
 
       - delay: 3s
 
-      # 0xA2 settings frame: Nominal=48.00V  Float=54.40V  MaxCurrent=100.00A
+      # 0xA2 settings frame: Rated=48.00V  Float=54.40V  MaxCurrent=100.00A
       - lambda: |-
           id(ampinvt0).on_ampinvt_modbus_data({
             0x01, 0xA2, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0xC0,

--- a/esp8266-anenji-example.yaml
+++ b/esp8266-anenji-example.yaml
@@ -106,8 +106,8 @@ sensor:
       name: "MPPT Temperature"
     battery_temperature:
       name: "Battery Temperature"
-    nominal_voltage:
-      name: "Nominal Voltage"
+    rated_voltage:
+      name: "Rated Voltage"
     max_charge_current_limit:
       name: "Max Charge Current Limit"
 

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -25,7 +25,7 @@ class TestSensorDefs:
         assert sensor.CONF_BATTERY_TEMPERATURE in sensor.SENSOR_DEFS
         assert sensor.CONF_TODAY_YIELD in sensor.SENSOR_DEFS
         assert sensor.CONF_GENERATION_TOTAL in sensor.SENSOR_DEFS
-        assert sensor.CONF_NOMINAL_VOLTAGE in sensor.SENSOR_DEFS
+        assert sensor.CONF_RATED_VOLTAGE in sensor.SENSOR_DEFS
         assert sensor.CONF_MAX_CHARGE_CURRENT_LIMIT in sensor.SENSOR_DEFS
         assert len(sensor.SENSOR_DEFS) == 9
 


### PR DESCRIPTION
## Summary

- Decodes all fields from the 26-byte Anenji `0xA2` settings response and logs them at INFO level
- Publishes `nominal_voltage` and `max_charge_current_limit` sensors (already supported)
- Enables the `0xA2` settings request after each status poll

**Fields decoded:**

| Byte(s) | Field |
|---------|-------|
| 3 | Battery type (Lead-acid MF / Gel / Liquid / Lithium) |
| 4 | Identification method (Auto / Manual) |
| 5 | Number of batteries |
| 6 | Load control method |
| 7 | Local address |
| 8 | Baud rate |
| 9-10 | Rated voltage (0.01 V resolution) |
| 11-12 | Equal charge voltage upper limit (0.01 V resolution) |
| 13-14 | Float charge voltage upper limit (0.01 V resolution) |
| 15-16 | Discharge voltage lower limit (0.01 V resolution) |
| 17-18 | HW max charge current, user-unchangeable (0.01 A resolution) |
| 19-20 | Max charge current limit (0.01 A resolution) |
| 21-22 | Running charging current limit (0.01 A resolution) |

## Test plan

- [x] Flash Anenji device and confirm settings frame is logged after each status poll
- [x] Verify decoded values match the device configuration
