### PR TITLE
Add charging_power sensor

### DIFF
--- a/components/ampinvt/ampinvt.cpp
+++ b/components/ampinvt/ampinvt.cpp
@@ -141,10 +141,10 @@ void Ampinvt::on_ampinvt_status_data_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->overvoltage_protection_status_binary_sensor_,
                        (bool) (ctl_status_byte & ControlStatusBits::OVERVOLTAGE_PROTECTION));
 
+  this->publish_state_(this->pv_voltage_sensor_, ampinvt_get_16bit(6) * 0.1f);
+
   float battery_voltage = ampinvt_get_16bit(8) * 0.01f;
   float charge_current = ampinvt_get_16bit(10) * 0.01f;
-
-  this->publish_state_(this->pv_voltage_sensor_, ampinvt_get_16bit(6) * 0.1f);
   this->publish_state_(this->battery_voltage_sensor_, battery_voltage);
   this->publish_state_(this->charge_current_sensor_, charge_current);
   this->publish_state_(this->charging_power_sensor_, battery_voltage * charge_current);
@@ -244,10 +244,10 @@ void Ampinvt::on_anenji_status_data_(const std::vector<uint8_t> &data) {
                        (bool) (ctl_status_byte & ControlStatusBits::LOAD_OUTPUT));
   this->publish_state_(this->fan_relay_status_binary_sensor_, (bool) (ctl_status_byte & ControlStatusBits::FAN_RELAY));
 
+  this->publish_state_(this->pv_voltage_sensor_, ampinvt_get_16bit(6) * 0.1f);
+
   float battery_voltage = ampinvt_get_16bit(8) * 0.01f;
   float charge_current = ampinvt_get_16bit(10) * 0.01f;
-
-  this->publish_state_(this->pv_voltage_sensor_, ampinvt_get_16bit(6) * 0.1f);
   this->publish_state_(this->battery_voltage_sensor_, battery_voltage);
   this->publish_state_(this->charge_current_sensor_, charge_current);
   this->publish_state_(this->charging_power_sensor_, battery_voltage * charge_current);

--- a/components/ampinvt/ampinvt.cpp
+++ b/components/ampinvt/ampinvt.cpp
@@ -141,9 +141,13 @@ void Ampinvt::on_ampinvt_status_data_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->overvoltage_protection_status_binary_sensor_,
                        (bool) (ctl_status_byte & ControlStatusBits::OVERVOLTAGE_PROTECTION));
 
+  float battery_voltage = ampinvt_get_16bit(8) * 0.01f;
+  float charge_current = ampinvt_get_16bit(10) * 0.01f;
+
   this->publish_state_(this->pv_voltage_sensor_, ampinvt_get_16bit(6) * 0.1f);
-  this->publish_state_(this->battery_voltage_sensor_, ampinvt_get_16bit(8) * 0.01f);
-  this->publish_state_(this->charge_current_sensor_, ampinvt_get_16bit(10) * 0.01f);
+  this->publish_state_(this->battery_voltage_sensor_, battery_voltage);
+  this->publish_state_(this->charge_current_sensor_, charge_current);
+  this->publish_state_(this->charging_power_sensor_, battery_voltage * charge_current);
 
   this->publish_state_(this->mppt_temperature_sensor_, ((int16_t) ampinvt_get_16bit(12)) * 0.1f);
 
@@ -240,9 +244,13 @@ void Ampinvt::on_anenji_status_data_(const std::vector<uint8_t> &data) {
                        (bool) (ctl_status_byte & ControlStatusBits::LOAD_OUTPUT));
   this->publish_state_(this->fan_relay_status_binary_sensor_, (bool) (ctl_status_byte & ControlStatusBits::FAN_RELAY));
 
+  float battery_voltage = ampinvt_get_16bit(8) * 0.01f;
+  float charge_current = ampinvt_get_16bit(10) * 0.01f;
+
   this->publish_state_(this->pv_voltage_sensor_, ampinvt_get_16bit(6) * 0.1f);
-  this->publish_state_(this->battery_voltage_sensor_, ampinvt_get_16bit(8) * 0.01f);
-  this->publish_state_(this->charge_current_sensor_, ampinvt_get_16bit(10) * 0.01f);
+  this->publish_state_(this->battery_voltage_sensor_, battery_voltage);
+  this->publish_state_(this->charge_current_sensor_, charge_current);
+  this->publish_state_(this->charging_power_sensor_, battery_voltage * charge_current);
 
   this->publish_state_(this->mppt_temperature_sensor_, ((int16_t) ampinvt_get_16bit(12)) * 0.1f);
 
@@ -309,6 +317,7 @@ void Ampinvt::publish_device_unavailable_() {
   this->publish_state_(this->generation_total_sensor_, NAN);
   this->publish_state_(this->rated_voltage_sensor_, NAN);
   this->publish_state_(this->max_charge_current_limit_sensor_, NAN);
+  this->publish_state_(this->charging_power_sensor_, NAN);
 }
 
 void Ampinvt::reset_online_status_tracker_() {
@@ -398,6 +407,7 @@ void Ampinvt::dump_config() {
   LOG_SENSOR("", "Generation Total", this->generation_total_sensor_);
   LOG_SENSOR("", "Rated Voltage", this->rated_voltage_sensor_);
   LOG_SENSOR("", "Max Charge Current Limit", this->max_charge_current_limit_sensor_);
+  LOG_SENSOR("", "Charging Power", this->charging_power_sensor_);
 
   LOG_TEXT_SENSOR("", "Operation Status", this->operation_status_text_sensor_);
 }

--- a/components/ampinvt/ampinvt.h
+++ b/components/ampinvt/ampinvt.h
@@ -113,6 +113,9 @@ class Ampinvt : public PollingComponent, public ampinvt_modbus::AmpinvtModbusDev
   void set_max_charge_current_limit_sensor(sensor::Sensor *max_charge_current_limit_sensor) {
     max_charge_current_limit_sensor_ = max_charge_current_limit_sensor;
   }
+  void set_charging_power_sensor(sensor::Sensor *charging_power_sensor) {
+    charging_power_sensor_ = charging_power_sensor;
+  }
 
   void set_operation_status_text_sensor(text_sensor::TextSensor *operation_status_text_sensor) {
     operation_status_text_sensor_ = operation_status_text_sensor;
@@ -159,6 +162,7 @@ class Ampinvt : public PollingComponent, public ampinvt_modbus::AmpinvtModbusDev
   sensor::Sensor *generation_total_sensor_{nullptr};
   sensor::Sensor *rated_voltage_sensor_{nullptr};
   sensor::Sensor *max_charge_current_limit_sensor_{nullptr};
+  sensor::Sensor *charging_power_sensor_{nullptr};
 
   Protocol protocol_{Protocol::AMPINVT};
 

--- a/components/ampinvt/sensor.py
+++ b/components/ampinvt/sensor.py
@@ -5,6 +5,7 @@ from esphome.const import (
     CONF_BATTERY_VOLTAGE,
     DEVICE_CLASS_CURRENT,
     DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_POWER,
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_VOLTAGE,
     STATE_CLASS_MEASUREMENT,
@@ -13,6 +14,7 @@ from esphome.const import (
     UNIT_CELSIUS,
     UNIT_KILOWATT_HOURS,
     UNIT_VOLT,
+    UNIT_WATT,
     UNIT_WATT_HOURS,
 )
 
@@ -29,6 +31,7 @@ CONF_TODAY_YIELD = "today_yield"
 CONF_GENERATION_TOTAL = "generation_total"
 CONF_RATED_VOLTAGE = "rated_voltage"
 CONF_MAX_CHARGE_CURRENT_LIMIT = "max_charge_current_limit"
+CONF_CHARGING_POWER = "charging_power"
 
 # key: sensor_schema kwargs
 SENSOR_DEFS = {
@@ -84,6 +87,12 @@ SENSOR_DEFS = {
         "unit_of_measurement": UNIT_AMPERE,
         "accuracy_decimals": 2,
         "device_class": DEVICE_CLASS_CURRENT,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+    CONF_CHARGING_POWER: {
+        "unit_of_measurement": UNIT_WATT,
+        "accuracy_decimals": 1,
+        "device_class": DEVICE_CLASS_POWER,
         "state_class": STATE_CLASS_MEASUREMENT,
     },
 }

--- a/esp32-anenji-example.yaml
+++ b/esp32-anenji-example.yaml
@@ -112,6 +112,8 @@ sensor:
       name: "Rated Voltage"
     max_charge_current_limit:
       name: "Max Charge Current Limit"
+    charging_power:
+      name: "Charging Power"
 
 text_sensor:
   - platform: ampinvt

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -127,6 +127,8 @@ sensor:
       name: "Today Yield"
     generation_total:
       name: "Total Generation"
+    charging_power:
+      name: "Charging Power"
 
 text_sensor:
   - platform: ampinvt

--- a/esp8266-anenji-example.yaml
+++ b/esp8266-anenji-example.yaml
@@ -110,6 +110,8 @@ sensor:
       name: "Rated Voltage"
     max_charge_current_limit:
       name: "Max Charge Current Limit"
+    charging_power:
+      name: "Charging Power"
 
 text_sensor:
   - platform: ampinvt

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -124,6 +124,8 @@ sensor:
       name: "Today Yield"
     generation_total:
       name: "Total Generation"
+    charging_power:
+      name: "Charging Power"
 
 text_sensor:
   - platform: ampinvt

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -27,7 +27,8 @@ class TestSensorDefs:
         assert sensor.CONF_GENERATION_TOTAL in sensor.SENSOR_DEFS
         assert sensor.CONF_RATED_VOLTAGE in sensor.SENSOR_DEFS
         assert sensor.CONF_MAX_CHARGE_CURRENT_LIMIT in sensor.SENSOR_DEFS
-        assert len(sensor.SENSOR_DEFS) == 9
+        assert sensor.CONF_CHARGING_POWER in sensor.SENSOR_DEFS
+        assert len(sensor.SENSOR_DEFS) == 10
 
     def test_battery_voltage_present(self):
         from esphome.const import CONF_BATTERY_VOLTAGE


### PR DESCRIPTION
Closes #26.

A new `charging_power` sensor (W) derived from `battery_voltage * charge_current` is added for both Ampinvt and Anenji protocols. No additional protocol traffic is required as both values are already present in the status frame.

```yaml
sensor:
  - platform: ampinvt
    ...
    charging_power:
      name: "Charging Power"
```