### PR TITLE
Handle 0xDB write parameter echo response for Anenji protocol

### DIFF
--- a/components/ampinvt/ampinvt.cpp
+++ b/components/ampinvt/ampinvt.cpp
@@ -11,6 +11,7 @@ static const uint8_t AMPINVT_COMMAND_STATUS = 0xB3;
 static const uint8_t AMPINVT_COMMAND_SETTINGS = 0xB2;
 static const uint8_t ANENJI_COMMAND_STATUS = 0xA3;
 static const uint8_t ANENJI_COMMAND_SETTINGS = 0xA2;
+static const uint8_t ANENJI_COMMAND_WRITE_PARAMETER = 0xDB;
 
 static const char *const OPERATION_STATUS_CHARGING = "Charging";
 static const char *const OPERATION_STATUS_NOT_CHARGING = "Not Charging";
@@ -70,6 +71,9 @@ void Ampinvt::on_ampinvt_modbus_data(const std::vector<uint8_t> &data) {
       return;
     case ANENJI_COMMAND_SETTINGS:
       this->on_anenji_settings_data_(data);
+      return;
+    case ANENJI_COMMAND_WRITE_PARAMETER:
+      ESP_LOGI(TAG, "Write parameter acknowledged");
       return;
     default:
       ESP_LOGW(TAG, "Unsupported function code 0x%02X in frame: %s", function,


### PR DESCRIPTION
Closes #25.

The Anenji controller echoes the 0xDB frame back as acknowledgment after a successful write parameter command. Previously this triggered the default branch and was logged as an unsupported function code.

The handler is guarded to the Anenji protocol only — the Ampinvt protocol documentation exclusively defines 0xB2 and 0xB3, so 0xDB is not expected there.