### PR TITLE
Handle 0xEE error response for Anenji protocol

### DIFF
--- a/components/ampinvt/ampinvt.cpp
+++ b/components/ampinvt/ampinvt.cpp
@@ -12,6 +12,7 @@ static const uint8_t AMPINVT_COMMAND_SETTINGS = 0xB2;
 static const uint8_t ANENJI_COMMAND_STATUS = 0xA3;
 static const uint8_t ANENJI_COMMAND_SETTINGS = 0xA2;
 static const uint8_t ANENJI_COMMAND_WRITE_PARAMETER = 0xDB;
+static const uint8_t ANENJI_COMMAND_ERROR = 0xEE;
 
 static const char *const OPERATION_STATUS_CHARGING = "Charging";
 static const char *const OPERATION_STATUS_NOT_CHARGING = "Not Charging";
@@ -74,6 +75,9 @@ void Ampinvt::on_ampinvt_modbus_data(const std::vector<uint8_t> &data) {
       return;
     case ANENJI_COMMAND_WRITE_PARAMETER:
       ESP_LOGI(TAG, "Write parameter acknowledged");
+      return;
+    case ANENJI_COMMAND_ERROR:
+      ESP_LOGW(TAG, "Error response: code=0x%02X command=0x%02X control=0x%02X", data[2], data[3], data[4]);
       return;
     default:
       ESP_LOGW(TAG, "Unsupported function code 0x%02X in frame: %s", function,

--- a/components/ampinvt_modbus/ampinvt_modbus.cpp
+++ b/components/ampinvt_modbus/ampinvt_modbus.cpp
@@ -15,8 +15,12 @@ static const uint8_t AMPINVT_COMMAND_SETTINGS = 0xB2;
 // Anenji ANJ-48V protocol variant (shorter frames)
 static const uint8_t ANENJI_FRAME_SIZE_STATUS = 21;
 static const uint8_t ANENJI_FRAME_SIZE_SETTINGS = 26;
+static const uint8_t ANENJI_FRAME_SIZE_WRITE_PARAMETER = 8;
+static const uint8_t ANENJI_FRAME_SIZE_ERROR = 8;
 static const uint8_t ANENJI_COMMAND_STATUS = 0xA3;
 static const uint8_t ANENJI_COMMAND_SETTINGS = 0xA2;
+static const uint8_t ANENJI_COMMAND_WRITE_PARAMETER = 0xDB;
+static const uint8_t ANENJI_COMMAND_ERROR = 0xEE;
 
 uint8_t ampinvt_checksum(const uint8_t data[], const uint8_t len) {
   uint8_t checksum = 0;
@@ -73,6 +77,12 @@ bool AmpinvtModbus::parse_ampinvt_modbus_byte_(uint8_t byte) {
       break;
     case ANENJI_COMMAND_SETTINGS:
       frame_len = ANENJI_FRAME_SIZE_SETTINGS;
+      break;
+    case ANENJI_COMMAND_WRITE_PARAMETER:
+      frame_len = ANENJI_FRAME_SIZE_WRITE_PARAMETER;
+      break;
+    case ANENJI_COMMAND_ERROR:
+      frame_len = ANENJI_FRAME_SIZE_ERROR;
       break;
     default:
       // Unknown command, flush buffer immediately


### PR DESCRIPTION
Closes #29.

The Anenji controller sends a 0xEE error frame in response to failed commands. Previously this fell through to the default branch and was logged as an unsupported function code.

The frame structure per the NEW MPPT communication protocol V1.0 documentation:

| Byte | Description |
|------|-------------|
| 0 | Address |
| 1 | 0xEE (error feedback) |
| 2 | Error code |
| 3 | Original command code |
| 4 | Original control code |
| 5-6 | Spare |
| 7 | Checksum |

Error codes:
- `0x01`: Current state cannot complete operation
- `0x02`: Cannot recognize parameter code
- `0x03`: Parameter data overflow

The constant is named `ANENJI_COMMAND_ERROR` as 0xEE is only defined in the Anenji protocol documentation. The Ampinvt protocol document exclusively defines 0xB2 and 0xB3.