### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/ampinvt/ampinvt.cpp
+++ b/components/ampinvt/ampinvt.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace ampinvt {
+namespace esphome::ampinvt {
 
 static const char *const TAG = "ampinvt";
 
@@ -416,5 +415,4 @@ void Ampinvt::dump_config() {
   LOG_TEXT_SENSOR("", "Operation Status", this->operation_status_text_sensor_);
 }
 
-}  // namespace ampinvt
-}  // namespace esphome
+}  // namespace esphome::ampinvt

--- a/components/ampinvt/ampinvt.h
+++ b/components/ampinvt/ampinvt.h
@@ -6,8 +6,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/ampinvt_modbus/ampinvt_modbus.h"
 
-namespace esphome {
-namespace ampinvt {
+namespace esphome::ampinvt {
 
 enum class Protocol : uint8_t {
   AMPINVT = 0,
@@ -183,5 +182,4 @@ class Ampinvt : public PollingComponent, public ampinvt_modbus::AmpinvtModbusDev
   void track_online_status_();
 };
 
-}  // namespace ampinvt
-}  // namespace esphome
+}  // namespace esphome::ampinvt

--- a/components/ampinvt_modbus/ampinvt_modbus.cpp
+++ b/components/ampinvt_modbus/ampinvt_modbus.cpp
@@ -1,8 +1,7 @@
 #include "ampinvt_modbus.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ampinvt_modbus {
+namespace esphome::ampinvt_modbus {
 
 static const char *const TAG = "ampinvt_modbus";
 
@@ -160,5 +159,4 @@ void AmpinvtModbus::send(uint8_t address, uint8_t function, uint16_t start_addre
     this->flow_control_pin_->digital_write(false);
 }
 
-}  // namespace ampinvt_modbus
-}  // namespace esphome
+}  // namespace esphome::ampinvt_modbus

--- a/components/ampinvt_modbus/ampinvt_modbus.h
+++ b/components/ampinvt_modbus/ampinvt_modbus.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace ampinvt_modbus {
+namespace esphome::ampinvt_modbus {
 
 class AmpinvtModbusDevice;
 
@@ -53,5 +52,4 @@ class AmpinvtModbusDevice {
   uint8_t address_;
 };
 
-}  // namespace ampinvt_modbus
-}  // namespace esphome
+}  // namespace esphome::ampinvt_modbus


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.