### PR TITLE
Fix rx_buffer_ not cleared in test feed() helper

### DIFF
--- a/tests/components/ampinvt_modbus/common.h
+++ b/tests/components/ampinvt_modbus/common.h
@@ -44,8 +44,11 @@ class TestableAmpinvtModbus : public AmpinvtModbus {
 
   bool feed(const std::vector<uint8_t> &frame) {
     bool result = false;
-    for (uint8_t byte : frame)
+    for (uint8_t byte : frame) {
       result = parse_ampinvt_modbus_byte_(byte);
+      if (!result)
+        rx_buffer_.clear();
+    }
     return result;
   }
 };


### PR DESCRIPTION
The `feed()` helper in the test `common.h` did not clear `rx_buffer_` when `parse_ampinvt_modbus_byte_()` returned `false`, which signals either a parse error or a successfully completed frame.

This means calling `feed()` a second time on the same instance would start parsing with a stale buffer, causing incorrect behaviour. The tests already exercise this case (two consecutive `feed()` calls on the same instance).

The fix mirrors what `loop()` does in production: clear the buffer on a `false` return.