### PR TITLE
Add Charging Energy Today sensor to all example configurations

### DIFF
--- a/esp32-anenji-example.yaml
+++ b/esp32-anenji-example.yaml
@@ -114,10 +114,23 @@ sensor:
     max_charge_current_limit:
       name: "Max Charge Current Limit"
     charging_power:
+      id: inverter0_charging_power
       name: "Charging Power"
+  - platform: total_daily_energy
+    name: "Charging Energy Today"
+    icon: mdi:counter
+    power_id: inverter0_charging_power
+    accuracy_decimals: 3
+    unit_of_measurement: kWh
+    restore: true
+    filters:
+      - multiply: 0.001
 
 text_sensor:
   - platform: ampinvt
     ampinvt_id: ampinvt0
     operation_status:
       name: "Operation Status"
+
+time:
+  - platform: sntp

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -129,10 +129,23 @@ sensor:
     generation_total:
       name: "Total Generation"
     charging_power:
+      id: inverter0_charging_power
       name: "Charging Power"
+  - platform: total_daily_energy
+    name: "Charging Energy Today"
+    icon: mdi:counter
+    power_id: inverter0_charging_power
+    accuracy_decimals: 3
+    unit_of_measurement: kWh
+    restore: true
+    filters:
+      - multiply: 0.001
 
 text_sensor:
   - platform: ampinvt
     ampinvt_id: ampinvt0
     operation_status:
       name: "Operation Status"
+
+time:
+  - platform: sntp

--- a/esp8266-anenji-example.yaml
+++ b/esp8266-anenji-example.yaml
@@ -112,10 +112,23 @@ sensor:
     max_charge_current_limit:
       name: "Max Charge Current Limit"
     charging_power:
+      id: inverter0_charging_power
       name: "Charging Power"
+  - platform: total_daily_energy
+    name: "Charging Energy Today"
+    icon: mdi:counter
+    power_id: inverter0_charging_power
+    accuracy_decimals: 3
+    unit_of_measurement: kWh
+    restore: true
+    filters:
+      - multiply: 0.001
 
 text_sensor:
   - platform: ampinvt
     ampinvt_id: ampinvt0
     operation_status:
       name: "Operation Status"
+
+time:
+  - platform: sntp

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -126,10 +126,23 @@ sensor:
     generation_total:
       name: "Total Generation"
     charging_power:
+      id: inverter0_charging_power
       name: "Charging Power"
+  - platform: total_daily_energy
+    name: "Charging Energy Today"
+    icon: mdi:counter
+    power_id: inverter0_charging_power
+    accuracy_decimals: 3
+    unit_of_measurement: kWh
+    restore: true
+    filters:
+      - multiply: 0.001
 
 text_sensor:
   - platform: ampinvt
     ampinvt_id: ampinvt0
     operation_status:
       name: "Operation Status"
+
+time:
+  - platform: sntp


### PR DESCRIPTION
## Summary

- Add `id: inverter0_charging_power` to the `charging_power` sensor in all four example YAML files
- Add `time: - platform: sntp` (required by `total_daily_energy`)
- Add `total_daily_energy` sensor **Charging Energy Today** (W → kWh, `restore: true`)

Affects: `esp32-example.yaml`, `esp32-anenji-example.yaml`, `esp8266-example.yaml`, `esp8266-anenji-example.yaml`

## Motivation

Requested by a user running an Anenji ANJ-48V-100A MPPT controller. The `total_daily_energy` sensor is the most useful entity for the Home Assistant **Energy** dashboard panel.

## Test plan

- [ ] Flash one of the modified configs and verify the `Charging Energy Today` entity appears in Home Assistant
- [ ] Confirm the Energy dashboard picks up the sensor correctly
- [ ] Verify midnight reset works (powered by SNTP time source)

@TomsEDM Please give it a try! :-)